### PR TITLE
rtlwifi_new: Log errant action value leading to AMPDU_ERR

### DIFF
--- a/core.c
+++ b/core.c
@@ -1428,7 +1428,7 @@ static int rtl_op_ampdu_action(struct ieee80211_hw *hw,
 			 "IEEE80211_AMPDU_RX_STOP:TID:%d\n", tid);
 		return rtl_rx_agg_stop(hw, sta, tid);
 	default:
-		pr_err("IEEE80211_AMPDU_ERR!!!!:\n");
+		pr_err("IEEE80211_AMPDU_ERR for action %d!!!!:\n", action);
 		return -EOPNOTSUPP;
 	}
 	return 0;


### PR DESCRIPTION
Signed-off-by: Larry Finger <Larry.Finger@lwfinger.net>